### PR TITLE
Changed BTC fees

### DIFF
--- a/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/coin/CoinUtil.kt
+++ b/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/coin/CoinUtil.kt
@@ -45,9 +45,9 @@ class CoinUtil {
                         }
                     TestNet3Params.get() ->
                         when (txPriority) {
-                            TxPriority.LOW_PRIORITY -> 15000
-                            TxPriority.MEDIUM_PRIORITY -> 19000
-                            TxPriority.HIGH_PRIORITY -> 19000
+                            TxPriority.LOW_PRIORITY -> 100000
+                            TxPriority.MEDIUM_PRIORITY -> 200000
+                            TxPriority.HIGH_PRIORITY -> 400000
                         }
                     else -> return calculateFeeWithPriority(MainNetParams.get(), txPriority)
                 }

--- a/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/core/wallet/WalletService.kt
+++ b/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/core/wallet/WalletService.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.withContext
+import nl.tudelft.trustchain.musicdao.core.coin.CoinUtil
 import org.bitcoinj.core.Address
 import org.bitcoinj.core.Coin
 import org.bitcoinj.core.Transaction
@@ -91,6 +92,8 @@ class WalletService(val config: WalletConfig, private val app: WalletAppKit) {
             } ?: return false
 
         val sendRequest = SendRequest.to(targetAddress, Coin.valueOf(satoshiAmount))
+        val feePerKb = CoinUtil.calculateFeeWithPriority(config.networkParams, CoinUtil.TxPriority.MEDIUM_PRIORITY)
+        sendRequest.feePerKb = Coin.valueOf(feePerKb)
 
         return try {
             app.wallet().sendCoins(sendRequest)


### PR DESCRIPTION
- Updated `CoinUtil.calculateFeeWithPriority` to use significantly higher fee rates for the Bitcoin Testnet:
- `MEDIUM_PRIORITY` raised from 19 sat/vB → 200 sat/vB 
- Modified `WalletService.sendCoins` to:
- Use the updated `CoinUtil.calculateFeeWithPriority(...)` method
- Set `sendRequest.feePerKb` accordingly before sending transactions